### PR TITLE
[CDI] fix krazo missing bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.0</version>
                 </plugin>
 
                 <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -47,6 +47,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.lang-model</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
             <version>2.1.0</version>

--- a/web/src/main/java/it/mulders/polly/web/MvcToolkitHelper.java
+++ b/web/src/main/java/it/mulders/polly/web/MvcToolkitHelper.java
@@ -1,0 +1,22 @@
+package it.mulders.polly.web;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Produces;
+import jakarta.mvc.MvcContext;
+import org.eclipse.krazo.MvcContextImpl;
+
+
+@ApplicationScoped
+@Default
+public class MvcToolkitHelper {
+
+  @Produces
+  @RequestScoped
+  @Default
+  public MvcContext produceMvcContext() {
+    return new MvcContextImpl();
+  }
+
+}

--- a/web/src/main/java/it/mulders/polly/web/home/HomeController.java
+++ b/web/src/main/java/it/mulders/polly/web/home/HomeController.java
@@ -1,6 +1,7 @@
 package it.mulders.polly.web.home;
 
 import de.chkal.mvctoolbox.core.typesafe.ViewName;
+import jakarta.enterprise.context.RequestScoped;
 import jakarta.mvc.Controller;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -8,6 +9,7 @@ import jakarta.ws.rs.Produces;
 
 @Controller
 @Path("/")
+@RequestScoped
 public class HomeController {
     public enum Views {
         @ViewName("home.jsp")

--- a/web/src/main/java/module-info.java
+++ b/web/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module confbuddy.web {
     requires java.net.http;
     requires jakarta.mvc;
     requires jakarta.validation;
+    requires static jakarta.cdi;
     requires jakarta.ws.rs;
     requires mvc.toolbox.core;
 

--- a/web/src/main/webapp/WEB-INF/beans.xml
+++ b/web/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,3 @@
+<beans>
+  <trim />
+</beans>


### PR DESCRIPTION
Here's one way to do it.
Krazo's `MvcContextImpl` is in an archive without `beans.xml`, so we need to add a producer (or just extend it).
I got a message the home controller needs to be a bean, too.

Part of the answer from the Stack Overflow question: https://stackoverflow.com/questions/76081454/weld-001408-unsatisfied-dependencies-in-openliberty-with-implicit-bean-scanning/76083634#76083634 (link to answer).