### PR TITLE
(chore) make structurizr portable

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,10 +23,10 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>generate-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <outputDirectory>${project.build.directory}/doc-src</outputDirectory>
                             <resources>
@@ -45,10 +45,10 @@
                 <executions>
                     <execution>
                         <id>render-diagrams</id>
-                        <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <executable>structurizr</executable>
                             <arguments>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,28 +20,25 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
+                <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>clean-images-in-srcdir</id>
-                        <phase>clean</phase>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>clean</goal>
+                            <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <filesets>
-                                <fileset>
-                                    <directory>${project.basedir}/src/main/asciidoc/img</directory>
-                                    <includes>
-                                        <include>structurizr-*</include>
-                                    </includes>
-                                </fileset>
-                            </filesets>
+                            <outputDirectory>${project.build.directory}/doc-src</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/main/asciidoc</directory>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>
-
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -57,7 +54,7 @@
                             <arguments>
                                 <argument>export</argument>
                                 <argument>-o</argument>
-                                <argument>${project.basedir}/src/main/asciidoc/img</argument>
+                                <argument>${project.build.directory}/doc-src/img</argument>
                                 <argument>-w</argument>
                                 <argument>${project.basedir}/src/main/structurizr/workspace.dsl</argument>
                                 <argument>-f</argument>
@@ -101,7 +98,7 @@
                             <requires>
                                 <require>asciidoctor-diagram</require>
                             </requires>
-                            <sourceDirectory>${project.basedir}/src/main/asciidoc</sourceDirectory>
+                            <sourceDirectory>${project.build.directory}/doc-src</sourceDirectory>
                             <sourceDocumentName>index.adoc</sourceDocumentName>
                         </configuration>
                     </execution>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -19,6 +19,55 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-images-in-srcdir</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.basedir}/src/main/asciidoc/img</directory>
+                                    <includes>
+                                        <include>structurizr-*</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>render-diagrams</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>structurizr</executable>
+                            <arguments>
+                                <argument>export</argument>
+                                <argument>-o</argument>
+                                <argument>${project.basedir}/src/main/asciidoc/img</argument>
+                                <argument>-w</argument>
+                                <argument>${project.basedir}/src/main/structurizr/workspace.dsl</argument>
+                                <argument>-f</argument>
+                                <argument>plantuml</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>3.2.0</version>

--- a/docs/render-diagrams.sh
+++ b/docs/render-diagrams.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-rm -Rf src/main/asciidoc/img/structurizr-*
-structurizr-cli export -o src/main/asciidoc/img -w src/main/structurizr/workspace.dsl -f plantuml

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.6.3</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.14</version>


### PR DESCRIPTION
* use structurzr executable, as the -cli variant is unmaintained for almost a year now
* Do not require user to execute a shell script
* Do not require user to do cleanup via shellscript (we can configure the m-clean-plugin
* Replace script logic with exec-m-p for now (maybe write a maven-plugin later) within this code repo
